### PR TITLE
Initial contribution to NLB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # aws-terraform-nlb
+
+## Usage:
+
+``` HCL
+module "net_lb" {
+  source      = "modules/network_load_balancer"
+  nlb_name    = "${var.name}-internal"
+  environment = "${var.environment}"
+  vpc_id      = "${module.base_network.vpc_id}"
+  nlb_facing  = "internal"
+
+  nlb_subnet_ids = "${module.base_network.public_subnets}"
+
+  # tell terraform how many to expect
+  nlb_eni_count = "${length(var.private_subnets)}"
+  
+  nlb_listener_map         = "${var.nlb_listener_map}"
+  nlb_tg_map               = "${var.nlb_tg_map}"
+  nlb_hc_map               = "${var.nlb_hc_map}"
+  force_destroy_log_bucket = "${var.force_destroy_log_bucket}"
+
+  nlb_tags = "${merge(local.full_tags["internal_nlb"], local.full_tags["default_tags"])}"
+```

--- a/README.md
+++ b/README.md
@@ -4,21 +4,67 @@
 
 ``` HCL
 module "net_lb" {
-  source      = "modules/network_load_balancer"
-  nlb_name    = "${var.name}-internal"
-  environment = "${var.environment}"
-  vpc_id      = "${module.base_network.vpc_id}"
-  nlb_facing  = "internal"
+  source                          = "git@github.com:rackspace-infrastructure-automation/aws-terraform-nlb.git?ref=<git tag, branch, or commit hash here>"
+  nlb_name                        = "${var.name}-internal"
+  environment                     = "${var.environment}"
+  vpc_id                          = "${module.base_network.vpc_id}"
+  nlb_facing                      = "internal"
 
-  nlb_subnet_ids = "${module.base_network.public_subnets}"
+  nlb_subnet_ids                  = "${module.base_network.public_subnets}"
 
   # tell terraform how many to expect
-  nlb_eni_count = "${length(var.private_subnets)}"
+  nlb_eni_count                   = "${length(var.private_subnets)}"
   
-  nlb_listener_map         = "${var.nlb_listener_map}"
-  nlb_tg_map               = "${var.nlb_tg_map}"
-  nlb_hc_map               = "${var.nlb_hc_map}"
-  force_destroy_log_bucket = "${var.force_destroy_log_bucket}"
+  # see variables.tf for examples
+  nlb_listener_map                = "${var.nlb_listener_map}"
+  nlb_tg_map                      = "${var.nlb_tg_map}"
+  nlb_hc_map                      = "${var.nlb_hc_map}"
+  force_destroy_log_bucket        = "${var.force_destroy_log_bucket}"
 
-  nlb_tags = "${merge(local.full_tags["internal_nlb"], local.full_tags["default_tags"])}"
+  # enable alarm actions for TG alarms. vars available for these parameters
+  enable_cloudwatch_alarm_actions = "true"
+
+  nlb_tags                        ="${merge(local.full_tags["internal_nlb"], local.full_tags["default_tags"])}"
 ```
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| enable_cloudwatch_alarm_actions |  | string | `false` | no |
+| environment | Label: environment name e.g. dev; prod | string | `noenv` | no |
+| force_destroy_log_bucket | S3: A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
+| nlb_al_bucket | S3: Access Logs Bucket | string | `__UNSET__` | no |
+| nlb_alarm_topic | CloudWatch: SNS topic for alarm actions | string | `rackspace-support-urgent` | no |
+| nlb_cross_zone | NLB: configure cross zone load balancing | string | `true` | no |
+| nlb_eni_count | VPC: explicitly tell terraform how many subnets to expect | string | `0` | no |
+| nlb_facing | NLB: is this load-balancer "internal" or "external"? | string | `internal` | no |
+| nlb_hc_map | /* NLB: tg health checks e.g. nlb_hc_map  = {   "listener1" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     }   "listener2" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     } } */ | map | - | yes |
+| nlb_idle_timeout | NLB: idle timeout in seconds, not currently valid for LB type "network" | string | `60` | no |
+| nlb_listener_map | /*  NLB: listener map<br><br>e.g. nlb_listener_map = {   "0" = {     "port"            = "80"     "protocol"        = "TCP"     "target_group"    = "${aws_lb_target_group.nlb_tg.arn}"   } } */ | map | - | yes |
+| nlb_name | Label: name for this load balancer | string | - | yes |
+| nlb_subnet_ids | VPC: list of subnet ids (1 per AZ only) to attach to this NLB | list | - | yes |
+| nlb_subnet_map | VPC: **not implemented** subnet -> EIP mapping | map | `<map>` | no |
+| nlb_tags | Label: tags map | map | `<map>` | no |
+| nlb_tg_map | /*   NLB: target group map<br><br>e.g. nlb_tg_map  = {   "listener1" = {     "name"          = "listener1-tg-name"     "port"          = "80"     "protocol"      = "HTTP"     "dereg_delay"   = "300"     "target_type"   = "instance"   } } */ | map | - | yes |
+| nlb_unhealthy_hosts_alarm_evaluation_periods | CloudWatch: alarm sample count threhold | string | `2` | no |
+| nlb_unhealthy_hosts_alarm_period | CloudWatch: alarm sample period in seconds | string | `60` | no |
+| nlb_unhealthy_hosts_alarm_threshold | CloudWatch: number of unhealthy hosts to trigger on | string | `1` | no |
+| route53_zone_id | Route53: the zone_id in which to create our CNAME | string | `__UNSET__` | no |
+| vpc_id | VPC: VPC ID | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| dns_name | output: the DNS name of the load balancer |
+| load_balancer_arn_suffix | output: The ARN suffix for use with CloudWatch Metrics. |
+| load_balancer_id | output: the ID and ARN of the load balancer |
+| load_balancer_log_bucket | output: the ID of the log bucket we are using |
+| load_balancer_zone_id | output: The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record). |
+| nlb_eni_ips | NLB: the private IPs of this LB for use in EC2 security groups |
+| target_group_arn_suffixes | NLB: ARN suffixes of our target groups - can be used with CloudWatch. |
+| target_group_arns | NLB: ARNs of the target groups. Useful for passing to your Auto Scaling group. |
+| target_group_names | NLB: Name of the target group. Useful for passing to your CodeDeploy Deployment Group |
+

--- a/README.md
+++ b/README.md
@@ -1,31 +1,74 @@
 # aws-terraform-nlb
 
+This module provides the functionality to deploy a Network Load Balancer complete with listeners and target groups.
+
 ## Usage:
+this and other examples available [here](examples/)
 
-``` HCL
-module "net_lb" {
-  source                          = "git@github.com:rackspace-infrastructure-automation/aws-terraform-nlb.git?ref=<git tag, branch, or commit hash here>"
-  nlb_name                        = "${var.name}-internal"
-  environment                     = "${var.environment}"
-  vpc_id                          = "${module.base_network.vpc_id}"
-  nlb_facing                      = "internal"
-
-  nlb_subnet_ids                  = "${module.base_network.public_subnets}"
-
-  # tell terraform how many to expect
-  nlb_eni_count                   = "${length(var.private_subnets)}"
-  
-  # see variables.tf for examples
-  nlb_listener_map                = "${var.nlb_listener_map}"
-  nlb_tg_map                      = "${var.nlb_tg_map}"
-  nlb_hc_map                      = "${var.nlb_hc_map}"
-  force_destroy_log_bucket        = "${var.force_destroy_log_bucket}"
-
-  # enable alarm actions for TG alarms. vars available for these parameters
-  enable_cloudwatch_alarm_actions = "true"
-
-  nlb_tags                        ="${merge(local.full_tags["internal_nlb"], local.full_tags["default_tags"])}"
 ```
+module "nlb" {
+ source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-nlb.git?ref=<git tag, branch, or commit hash here>"
+ environment    = "Test"
+ nlb_name       = "MyNLB"
+
+ vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
+ nlb_subnet_ids = ["subnet-xxxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxxx"]
+
+ # enable alarm actions for TG alarms. vars available for these parameters
+ enable_cloudwatch_alarm_actions = "true"
+
+ nlb_tags      = {
+     "role"    = "load-balancer"
+     "contact" = "someone@somewhere.com"
+ }
+
+ nlb_listener_map = {
+   listener1 = {
+     port = 80
+   }
+
+   listener2 = {
+     port = 8080
+   }
+ }
+
+ # if `name` is not defined, then the map index is used for this value
+ nlb_tg_map = {
+   listener1 = {
+     name       = "listener1-tg-name"
+     port        = 80
+     dereg_delay = 300
+     target_type = "instance"
+   }
+
+   listener2 = {
+     name       = "listener2-tg-name"
+     port        = 8080
+     dereg_delay = 300
+     target_type = "instance"
+   }
+ }
+
+ nlb_hc_map = {
+   listener1 = {
+     protocol            = "TCP"
+     healthy_threshold   = 3
+     unhealthy_threshold = 3
+     interval            = 30
+   }
+
+   listener2 = {
+     protocol            = "HTTP"
+     healthy_threshold   = 3
+     unhealthy_threshold = 3
+     interval            = 30
+     matcher             = "200-399"
+     path                = "/"
+   }
+ }
+}
+```
+
 
 
 ## Inputs
@@ -33,22 +76,19 @@ module "net_lb" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | enable_cloudwatch_alarm_actions |  | string | `false` | no |
-| environment | Label: environment name e.g. dev; prod | string | `noenv` | no |
-| force_destroy_log_bucket | S3: A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
-| nlb_al_bucket | S3: Access Logs Bucket | string | `__UNSET__` | no |
-| nlb_alarm_topic | CloudWatch: SNS topic for alarm actions | string | `rackspace-support-urgent` | no |
+| environment | Label: environment name e.g. dev; prod | string | `test` | no |
+| nlb_alarm_topic | CloudWatch: SNS topic for alarm actions | string | `rackspace-support-emergency` | no |
 | nlb_cross_zone | NLB: configure cross zone load balancing | string | `true` | no |
 | nlb_eni_count | VPC: explicitly tell terraform how many subnets to expect | string | `0` | no |
-| nlb_facing | NLB: is this load-balancer "internal" or "external"? | string | `internal` | no |
-| nlb_hc_map | /* NLB: tg health checks e.g. nlb_hc_map  = {   "listener1" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     }   "listener2" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     } } */ | map | - | yes |
-| nlb_idle_timeout | NLB: idle timeout in seconds, not currently valid for LB type "network" | string | `60` | no |
-| nlb_listener_map | /*  NLB: listener map<br><br>e.g. nlb_listener_map = {   "0" = {     "port"            = "80"     "protocol"        = "TCP"     "target_group"    = "${aws_lb_target_group.nlb_tg.arn}"   } } */ | map | - | yes |
+| nlb_facing | NLB: is this load-balancer "internal" or "external"? | string | `external` | no |
+| nlb_hc_map | /* NLB: tg health checks e.g. nlb_hc_map  = {   "listener1" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     }   "listener2" = {       protocol            = "HTTP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"       matcher             = "200-399"       path                = "/"     } } */ | map | - | yes |
+| nlb_listener_map | /*  NLB: listener map<br><br>e.g. nlb_listener_map = {   "0" = {     "port"            = "80"     "target_group"    = "arn:aws:elasticloadbalancing:xxxxxxx" # optionally specify existing TG ARN   } } */ | map | - | yes |
 | nlb_name | Label: name for this load balancer | string | - | yes |
 | nlb_subnet_ids | VPC: list of subnet ids (1 per AZ only) to attach to this NLB | list | - | yes |
 | nlb_subnet_map | VPC: **not implemented** subnet -> EIP mapping | map | `<map>` | no |
 | nlb_tags | Label: tags map | map | `<map>` | no |
-| nlb_tg_map | /*   NLB: target group map<br><br>e.g. nlb_tg_map  = {   "listener1" = {     "name"          = "listener1-tg-name"     "port"          = "80"     "protocol"      = "HTTP"     "dereg_delay"   = "300"     "target_type"   = "instance"   } } */ | map | - | yes |
-| nlb_unhealthy_hosts_alarm_evaluation_periods | CloudWatch: alarm sample count threhold | string | `2` | no |
+| nlb_tg_map | /*   NLB: target group map<br><br>e.g. nlb_tg_map  = {   "listener1" = {     "name"          = "listener1-tg-name"     "port"          = "80"     "dereg_delay"   = "300"     "target_type"   = "instance"   } } */ | map | - | yes |
+| nlb_unhealthy_hosts_alarm_evaluation_periods | CloudWatch: alarm sample count threhold | string | `10` | no |
 | nlb_unhealthy_hosts_alarm_period | CloudWatch: alarm sample period in seconds | string | `60` | no |
 | nlb_unhealthy_hosts_alarm_threshold | CloudWatch: number of unhealthy hosts to trigger on | string | `1` | no |
 | route53_zone_id | Route53: the zone_id in which to create our CNAME | string | `__UNSET__` | no |
@@ -61,7 +101,6 @@ module "net_lb" {
 | dns_name | output: the DNS name of the load balancer |
 | load_balancer_arn_suffix | output: The ARN suffix for use with CloudWatch Metrics. |
 | load_balancer_id | output: the ID and ARN of the load balancer |
-| load_balancer_log_bucket | output: the ID of the log bucket we are using |
 | load_balancer_zone_id | output: The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record). |
 | nlb_eni_ips | NLB: the private IPs of this LB for use in EC2 security groups |
 | target_group_arn_suffixes | NLB: ARN suffixes of our target groups - can be used with CloudWatch. |

--- a/data.tf
+++ b/data.tf
@@ -55,22 +55,6 @@ data "aws_network_interfaces" "nlb_enis" {
 }
 */
 
-data "aws_iam_policy_document" "nlb_log_bucket_policy" {
-  # only generate this policy if we are going to create the bucket
-  count = "${var.nlb_al_bucket == "__UNSET__" ? 1:0}"
-
-  statement {
-    actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::${var.nlb_name}-${var.environment}-${random_id.random_string.hex}-nlb-logs/AWSLogs/*"]
-    effect    = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${data.aws_elb_service_account.nlb_svc_acct.arn}"]
-    }
-  }
-}
-
 data "aws_route53_zone" "provided" {
   count   = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
   zone_id = "${var.route53_zone_id}"

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,72 @@
+# Determine NLB AWS Account ID for bucket policy: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy 
+data "aws_elb_service_account" "nlb_svc_acct" {}
+
+resource "random_id" "random_string" {
+  byte_length = 8
+
+  keepers {
+    name = "${var.nlb_name}"
+  }
+}
+
+data "aws_network_interface" "nlb_eni" {
+  # this data source does not permit muliple results
+
+  # Allow for a static value for nlb_eni_count
+  count = "${var.nlb_eni_count > 0 ? "${var.nlb_eni_count}" : length(var.nlb_subnet_ids)}"
+
+  filter {
+    name = "description"
+
+    values = [
+      "ELB net/${var.nlb_name}/*",
+    ]
+  }
+  filter {
+    name = "subnet-id"
+
+    values = [
+      "${element(var.nlb_subnet_ids,count.index)}",
+    ]
+  }
+  # terraform has no way of determining this dependency unaided
+  depends_on = ["aws_lb.nlb"]
+}
+
+/*
+# Error: data.aws_network_interfaces.nlb_enis: Provider doesn't support data source: aws_network_interfaces
+# and yet: https://www.terraform.io/docs/providers/aws/d/network_interfaces.html
+
+data "aws_network_interfaces" "nlb_enis" {
+  filter {
+    name = "description"
+
+    values = [
+      "ELB net/${var.nlb_name}/*",
+    ]
+  }
+  depends_on = ["aws_lb.nlb"]
+}
+*/
+
+data "aws_iam_policy_document" "nlb_log_bucket_policy" {
+  # only generate this policy if we are going to create the bucket
+  count = "${var.nlb_al_bucket == "__UNSET__" ? 1:0}"
+
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${var.nlb_name}-${var.environment}-${random_id.random_string.hex}-nlb-logs/AWSLogs/*"]
+    effect    = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_elb_service_account.nlb_svc_acct.arn}"]
+    }
+  }
+}
+
+data "aws_route53_zone" "provided" {
+  count   = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
+  zone_id = "${var.route53_zone_id}"
+}
+

--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,10 @@
 # Determine NLB AWS Account ID for bucket policy: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy 
 data "aws_elb_service_account" "nlb_svc_acct" {}
 
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 resource "random_id" "random_string" {
   byte_length = 8
 
@@ -22,6 +26,7 @@ data "aws_network_interface" "nlb_eni" {
       "ELB net/${var.nlb_name}/*",
     ]
   }
+
   filter {
     name = "subnet-id"
 
@@ -29,6 +34,7 @@ data "aws_network_interface" "nlb_eni" {
       "${element(var.nlb_subnet_ids,count.index)}",
     ]
   }
+
   # terraform has no way of determining this dependency unaided
   depends_on = ["aws_lb.nlb"]
 }
@@ -69,4 +75,3 @@ data "aws_route53_zone" "provided" {
   count   = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
   zone_id = "${var.route53_zone_id}"
 }
-

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,60 @@
+module "nlb" {
+  source         = "../"
+  environment    = "Test"
+  nlb_name       = "MyNLB"
+  vpc_id         = "vpc-xxxxxxxxxxxxxxxx"
+  nlb_subnet_ids = ["subnet-xxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxx"]
+
+  # enable alarm actions for TG alarms. vars available for these parameters
+  enable_cloudwatch_alarm_actions = "true"
+
+  nlb_tags = {
+    "role"    = "load-balancer"
+    "contact" = "someone@somewhere.com"
+  }
+
+  nlb_listener_map = {
+    listener1 = {
+      port = 80
+    }
+
+    listener2 = {
+      port = 8080
+    }
+  }
+
+  # if `name` is not defined, then the map index is used for this value
+  nlb_tg_map = {
+    listener1 = {
+      name        = "listener1-tg-name"
+      port        = 80
+      dereg_delay = 300
+      target_type = "instance"
+    }
+
+    listener2 = {
+      name        = "listener2-tg-name"
+      port        = 8080
+      dereg_delay = 300
+      target_type = "instance"
+    }
+  }
+
+  nlb_hc_map = {
+    listener1 = {
+      protocol            = "TCP"
+      healthy_threshold   = 3
+      unhealthy_threshold = 3
+      interval            = 30
+    }
+
+    listener2 = {
+      protocol            = "HTTP"
+      healthy_threshold   = 3
+      unhealthy_threshold = 3
+      interval            = 30
+      matcher             = "200-399"
+      path                = "/"
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,18 @@
+locals {
+  default_tg_params = {
+    dereg_delay = 300
+    target_type = "instance"
+  }
+
+  default_health_check = {
+    protocol            = "TCP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tg_keys = "${keys(var.nlb_tg_map)}"
+  lm_keys = "${keys(var.nlb_listener_map)}"
+  hc_keys = "${keys(var.nlb_hc_map)}"
+}
+

--- a/locals.tf
+++ b/locals.tf
@@ -14,4 +14,6 @@ locals {
   tg_keys = "${keys(var.nlb_tg_map)}"
   lm_keys = "${keys(var.nlb_listener_map)}"
   hc_keys = "${keys(var.nlb_hc_map)}"
+
+  tags = "${merge(var.nlb_tags, map("Environment", "${var.environment}", "ServiceProvider", "Rackspace"))}"
 }

--- a/locals.tf
+++ b/locals.tf
@@ -15,4 +15,3 @@ locals {
   lm_keys = "${keys(var.nlb_listener_map)}"
   hc_keys = "${keys(var.nlb_hc_map)}"
 }
-

--- a/main.tf
+++ b/main.tf
@@ -15,22 +15,6 @@ resource "aws_lb" "nlb" {
     prefix  = "AWSLogs"
     enabled = true
   }
-
-  /*
-  # there is no graceful way to define a variable number of subnet mappings
-  see:
-  https://github.com/hashicorp/terraform/issues/7034
-  https://serverfault.com/questions/833810/terraform-use-nested-loops-with-count
-
-  subnet_mapping {
-    subnet_id     = "${var.subnet_public[0]}"
-    allocation_id = "eipalloc-54157069"
-  }
-  subnet_mapping {
-    subnet_id     = "${var.subnet_public[1]}"
-    allocation_id = "eipalloc-8d096cb0"
-  }
-  */
 }
 
 resource "aws_lb_target_group" "nlb_tg" {
@@ -93,7 +77,7 @@ resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
   actions_enabled = "${var.enable_cloudwatch_alarm_actions}"
 
   alarm_actions = [
-    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
+    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.nlb_alarm_topic}",
   ]
 
   alarm_description   = "Unhealthy Host count is above threshold, creating ticket."
@@ -117,5 +101,4 @@ resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
   statistic = "Average"
   threshold = "${var.nlb_unhealthy_hosts_alarm_threshold}"
   unit      = "Count"
-
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,213 @@
+locals {
+  default_tg_params = {
+    dereg_delay = 300
+    target_type = "instance"
+  }
+
+  default_health_check = {
+    protocol            = "TCP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tg_keys = "${keys(var.nlb_tg_map)}"
+  lm_keys = "${keys(var.nlb_listener_map)}"
+  hc_keys = "${keys(var.nlb_hc_map)}"
+}
+
+# Determine NLB AWS Account ID for bucket policy: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy 
+data "aws_elb_service_account" "nlb_svc_acct" {}
+
+resource "random_id" "random_string" {
+  byte_length = 8
+
+  keepers {
+    name = "${var.nlb_name}"
+  }
+}
+
+resource "aws_lb" "nlb" {
+  name               = "${var.nlb_name}"
+  internal           = "${var.nlb_facing == "internal" ? true : false}"
+  load_balancer_type = "network"
+
+  idle_timeout = "${var.nlb_idle_timeout}"
+
+  enable_cross_zone_load_balancing = "${var.nlb_cross_zone}"
+
+  subnets = ["${var.nlb_subnet_ids}"]
+  tags    = "${var.nlb_tags}"
+
+  access_logs {
+    bucket  = "${var.nlb_al_bucket == "__UNSET__" ? element(aws_s3_bucket.nlb_log_bucket.*.id,0) : var.nlb_al_bucket}"
+    prefix  = "AWSLogs"
+    enabled = true
+  }
+
+  /*
+  # there is no graceful way to define a variable number of subnet mappings
+  see:
+  https://github.com/hashicorp/terraform/issues/7034
+  https://serverfault.com/questions/833810/terraform-use-nested-loops-with-count
+
+  subnet_mapping {
+    subnet_id     = "${var.subnet_public[0]}"
+    allocation_id = "eipalloc-54157069"
+  }
+  subnet_mapping {
+    subnet_id     = "${var.subnet_public[1]}"
+    allocation_id = "eipalloc-8d096cb0"
+  }
+  */
+}
+
+resource "aws_lb_target_group" "nlb_tg" {
+  count = "${length(local.tg_keys)}"
+
+  vpc_id = "${var.vpc_id}"
+
+  name = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"name", "__UNSET__") == "__UNSET__"
+       ? "${var.nlb_name}-${element(local.tg_keys,count.index)}-tg"
+       : lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"name", "__UNSET__")}"
+
+  port                 = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"port")}"
+  protocol             = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"protocol")}"
+  deregistration_delay = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"dereg_delay")}"
+  target_type          = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"target_type")}"
+
+  health_check {
+    protocol            = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"protocol")}"
+    healthy_threshold   = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"healthy_threshold")}"
+    unhealthy_threshold = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"unhealthy_threshold")}"
+    interval            = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"interval")}"
+  }
+}
+
+/*
+this does not belong here
+resource "aws_lb_target_group_attachment" "nlb_tg_attachment" {
+  count            = "${length(var.nlb_tg_instances)}"
+  target_group_arn = "${aws_lb_target_group.nlb_tg[count.index].arn}"
+  target_id        = "${element(module.ec2_ni.instance_id, count.index)}"
+  port             = 22
+}
+*/
+
+resource "aws_lb_listener" "nlb_listener" {
+  count = "${length(local.lm_keys)}"
+
+  load_balancer_arn = "${aws_lb.nlb.arn}"
+  port              = "${lookup(var.nlb_listener_map[element(local.lm_keys,count.index)],"port")}"
+  protocol          = "${lookup(var.nlb_listener_map[element(local.lm_keys,count.index)],"protocol")}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.nlb_tg.*.arn[count.index]}"
+    type             = "forward"
+  }
+}
+
+data "aws_network_interface" "nlb_eni" {
+  # this data source does not permit muliple results
+  count = "${var.nlb_eni_count}"
+
+  #count = "${length(var.nlb_subnet_ids)}"
+
+  filter {
+    name = "description"
+
+    values = [
+      "ELB net/${var.nlb_name}/*",
+    ]
+  }
+  filter {
+    name = "subnet-id"
+
+    values = [
+      "${element(var.nlb_subnet_ids,count.index)}",
+    ]
+  }
+  # terraform has no way of determining this dependency unaided
+  depends_on = ["aws_lb.nlb"]
+}
+
+data "aws_iam_policy_document" "nlb_log_bucket_policy" {
+  # only generate this policy if we are going to create the bucket
+  count = "${var.nlb_al_bucket == "__UNSET__" ? 1:0}"
+
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${var.nlb_name}-${var.environment}-${random_id.random_string.hex}-nlb-logs/AWSLogs/*"]
+    effect    = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_elb_service_account.nlb_svc_acct.arn}"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "nlb_log_bucket" {
+  # should we create a bucket or use the one provided?
+  count = "${var.nlb_al_bucket == "__UNSET__" ? 1:0}"
+
+  bucket        = "${var.nlb_name}-${var.environment}-${random_id.random_string.hex}-nlb-logs"
+  force_destroy = "${var.force_destroy_log_bucket}"
+
+  policy = "${data.aws_iam_policy_document.nlb_log_bucket_policy.json}"
+}
+
+/*
+data "aws_route53_zone" "provided" {
+  count   = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
+  zone_id = "${var.route53_zone_id}"
+}
+
+resource "aws_route53_record" "route53_nlb_cname" {
+  count = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
+
+  zone_id = "${var.route53_zone_id}"
+  name    = "${var.nlb_name}-${var.environment}-nlb"
+  records = ["${aws_lb.nlb.dns_name}"]
+  type    = "CNAME"
+  ttl     = "5"
+}
+*/
+/*
+resource "aws_cloudwatch_metric_alarm" "ni_lb_unhealthy_hosts" {
+  actions_enabled = "${var.enable_cloudwatch_alarm_actions}"
+
+
+  alarm_actions = [
+    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
+  ]
+
+
+  alarm_description   = "Unhealthy Host count is above threshold, creating ticket."
+  alarm_name          = "NLB Unhealthy Host Count - ${aws_lb.ni_lb.name}"
+  comparison_operator = "GreaterThanThreshold"
+
+
+  dimensions = {
+    LoadBalancer = "${aws_lb.ni_lb.arn_suffix}"
+    TargetGroup  = "${aws_lb_target_group.ni_lb_tg.arn_suffix}"
+  }
+
+
+  evaluation_periods = "${var.lb_unhealthy_hosts_alarm_evaluation_periods}"
+  metric_name        = "UnHealthyHostCount"
+  namespace          = "AWS/NetworkELB"
+
+
+  ok_actions = [
+    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
+  ]
+
+
+  period    = "${var.lb_unhealthy_hosts_alarm_period}"
+  statistic = "Average"
+  threshold = "${var.lb_unhealthy_hosts_alarm_threshold}"
+  unit      = "Count"
+}
+*/
+

--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
   actions_enabled = "${var.enable_cloudwatch_alarm_actions}"
 
   alarm_actions = [
-    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.nlb_alarm_topic}",
+    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
   ]
 
   alarm_description   = "Unhealthy Host count is above threshold, creating ticket."
@@ -149,7 +149,7 @@ resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
     TargetGroup  = "${aws_lb_target_group.nlb_tg.*.arn_suffix[count.index]}"
   }
 
-  evaluation_periods = "${var.nlb_unhealthy_hosts_alarm_evaluation_periods}"
+  evaluation_periods = "10"
   metric_name        = "UnHealthyHostCount"
   namespace          = "AWS/NetworkELB"
 
@@ -157,8 +157,8 @@ resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
     "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
   ]
 
-  period    = "${var.nlb_unhealthy_hosts_alarm_period}"
+  period    = "60"
   statistic = "Maximum"
-  threshold = "${var.nlb_unhealthy_hosts_alarm_threshold}"
+  threshold = "1"
   unit      = "Count"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -26,11 +26,6 @@ output "load_balancer_arn_suffix" {
   value = "${aws_lb.nlb.arn_suffix}"
 }
 
-# output: the ID of the log bucket we are using
-output "load_balancer_log_bucket" {
-  value = "${var.nlb_al_bucket == "__UNSET__" ? element(aws_s3_bucket.nlb_log_bucket.*.id,0) : var.nlb_al_bucket}"
-}
-
 # NLB: ARNs of the target groups. Useful for passing to your Auto Scaling group.
 output "target_group_arns" {
   value = "${flatten(aws_lb_target_group.nlb_tg.*.arn)}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,52 @@
+/*
+### Outputs section for the NLB module
+
+For consistency, it is intended to mimic as far as applicable the [community ALB module](https://github.com/terraform-aws-modules/terraform-aws-alb/blob/master/outputs.tf)
+[Parent module](https://github.com/terraform-aws-modules/terraform-aws-alb)
+
+*/
+
+# output: the DNS name of the load balancer
+output "dns_name" {
+  value = "${aws_lb.nlb.dns_name}"
+}
+
+# output: the ID and ARN of the load balancer
+output "load_balancer_id" {
+  value = "${aws_lb.nlb.id}"
+}
+
+# output: The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
+output "load_balancer_zone_id" {
+  value = "${aws_lb.nlb.zone_id}"
+}
+
+# output: The ARN suffix for use with CloudWatch Metrics.
+output "load_balancer_arn_suffix" {
+  value = "${aws_lb.nlb.arn_suffix}"
+}
+
+# output: the ID of the log bucket we are using
+output "load_balancer_log_bucket" {
+  value = "${var.nlb_al_bucket == "__UNSET__" ? element(aws_s3_bucket.nlb_log_bucket.*.id,0) : var.nlb_al_bucket}"
+}
+
+# NLB: ARNs of the target groups. Useful for passing to your Auto Scaling group.
+output "target_group_arns" {
+  value = "${flatten(aws_lb_target_group.nlb_tg.*.arn)}"
+}
+
+# NLB: ARN suffixes of our target groups - can be used with CloudWatch.
+output "target_group_arn_suffixes" {
+  value = "${flatten(aws_lb_target_group.nlb_tg.*.arn_suffix)}"
+}
+
+# NLB: Name of the target group. Useful for passing to your CodeDeploy Deployment Group
+output "target_group_names" {
+  value = "${flatten(aws_lb_target_group.nlb_tg.*.name)}"
+}
+
+# NLB: the private IPs of this LB for use in EC2 security groups
+output "nlb_eni_ips" {
+  value = "${flatten(data.aws_network_interface.nlb_eni.*.private_ips)}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -63,12 +63,6 @@ variable "nlb_tags" {
   }
 }
 
-# NLB: EC2 Instance list to add to target groups
-variable "nlb_tg_instances" {
-  type    = "list"
-  default = []
-}
-
 # S3: Access Logs Bucket
 variable "nlb_al_bucket" {
   default = "__UNSET__"
@@ -131,4 +125,31 @@ nlb_hc_map  = {
 */
 variable "nlb_hc_map" {
   type = "map"
+}
+
+variable "enable_cloudwatch_alarm_actions" {
+  type    = "string"
+  default = "false"
+}
+
+#
+#      CloudWatch Monitoring for Target Groups
+#
+
+# CloudWatch: alarm sample period in seconds
+variable "nlb_unhealthy_hosts_alarm_period" {
+  type    = "string"
+  default = "60"
+}
+
+# CloudWatch: number of unhealthy hosts to trigger on
+variable "nlb_unhealthy_hosts_alarm_threshold" {
+  type    = "string"
+  default = "1"
+}
+
+# CloudWatch: alarm sample count threhold
+variable "nlb_unhealthy_hosts_alarm_evaluation_periods" {
+  type    = "string"
+  default = "2"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,12 @@ variable "enable_cloudwatch_alarm_actions" {
 #      CloudWatch Monitoring for Target Groups
 #
 
+# CloudWatch: SNS topic for alarm actions
+variable "nlb_alarm_topic" {
+  type    = "string"
+  default = "rackspace-support-urgent"
+}
+
 # CloudWatch: alarm sample period in seconds
 variable "nlb_unhealthy_hosts_alarm_period" {
   type    = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -114,31 +114,3 @@ variable "enable_cloudwatch_alarm_actions" {
   type    = "string"
   default = "false"
 }
-
-#
-#      CloudWatch Monitoring for Target Groups
-#
-
-# CloudWatch: SNS topic for alarm actions
-variable "nlb_alarm_topic" {
-  type    = "string"
-  default = "rackspace-support-emergency"
-}
-
-# CloudWatch: alarm sample period in seconds
-variable "nlb_unhealthy_hosts_alarm_period" {
-  type    = "string"
-  default = "60"
-}
-
-# CloudWatch: number of unhealthy hosts to trigger on
-variable "nlb_unhealthy_hosts_alarm_threshold" {
-  type    = "string"
-  default = "1"
-}
-
-# CloudWatch: alarm sample count threhold
-variable "nlb_unhealthy_hosts_alarm_evaluation_periods" {
-  type    = "string"
-  default = "10"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "nlb_name" {
 # Label: environment name e.g. dev; prod
 variable environment {
   type    = "string"
-  default = "noenv"
+  default = "test"
 }
 
 # Route53: the zone_id in which to create our CNAME
@@ -41,12 +41,7 @@ variable "nlb_subnet_map" {
 
 # NLB: is this load-balancer "internal" or "external"? 
 variable "nlb_facing" {
-  default = "internal"
-}
-
-# NLB: idle timeout in seconds, not currently valid for LB type "network"
-variable "nlb_idle_timeout" {
-  default = 60
+  default = "external"
 }
 
 # NLB: configure cross zone load balancing
@@ -58,19 +53,7 @@ variable "nlb_cross_zone" {
 variable "nlb_tags" {
   type = "map"
 
-  default = {
-    "nlb" = true
-  }
-}
-
-# S3: Access Logs Bucket
-variable "nlb_al_bucket" {
-  default = "__UNSET__"
-}
-
-# S3: A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.
-variable "force_destroy_log_bucket" {
-  default = false
+  default = {}
 }
 
 /*  NLB: listener map
@@ -79,8 +62,7 @@ e.g.
 nlb_listener_map = {
   "0" = {
     "port"            = "80"
-    "protocol"        = "TCP"
-    "target_group"    = "${aws_lb_target_group.nlb_tg.arn}"
+    "target_group"    = "arn:aws:elasticloadbalancing:xxxxxxx" # optionally specify existing TG ARN
   }
 }
 */
@@ -96,7 +78,6 @@ nlb_tg_map  = {
   "listener1" = {
     "name"          = "listener1-tg-name"
     "port"          = "80"
-    "protocol"      = "HTTP"
     "dereg_delay"   = "300"
     "target_type"   = "instance"
   }
@@ -116,10 +97,12 @@ nlb_hc_map  = {
       interval            = "30"
     }
   "listener2" = {
-      protocol            = "TCP"
+      protocol            = "HTTP"
       healthy_threshold   = "3"
       unhealthy_threshold = "3"
       interval            = "30"
+      matcher             = "200-399"
+      path                = "/"
     }
 }
 */
@@ -139,7 +122,7 @@ variable "enable_cloudwatch_alarm_actions" {
 # CloudWatch: SNS topic for alarm actions
 variable "nlb_alarm_topic" {
   type    = "string"
-  default = "rackspace-support-urgent"
+  default = "rackspace-support-emergency"
 }
 
 # CloudWatch: alarm sample period in seconds
@@ -157,5 +140,5 @@ variable "nlb_unhealthy_hosts_alarm_threshold" {
 # CloudWatch: alarm sample count threhold
 variable "nlb_unhealthy_hosts_alarm_evaluation_periods" {
   type    = "string"
-  default = "2"
+  default = "10"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,136 @@
+# Label: name for this load balancer
+variable "nlb_name" {
+  type = "string"
+}
+
+# Label: environment name e.g. dev; prod
+variable environment {
+  type    = "string"
+  default = "noenv"
+}
+
+/*
+# Route53: the zone_id in which to create our CNAME
+variable "route53_zone_id" {
+  type    = "string"
+  default = "__UNSET__"
+}
+*/
+
+# VPC: list of subnet ids (1 per AZ only) to attach to this NLB
+variable "nlb_subnet_ids" {
+  type = "list"
+}
+
+# VPC: explicitly tell terraform how many to expect
+variable "nlb_eni_count" {
+  default = "0"
+}
+
+# VPC: VPC ID
+variable "vpc_id" {
+  type = "string"
+}
+
+# VPC: **not implemented** subnet -> EIP mapping
+variable "nlb_subnet_map" {
+  type = "map"
+
+  default = {
+    "0" = ["eip-1", "subnet-1"]
+  }
+}
+
+# NLB: is this load-balancer "internal" or "external"? 
+variable "nlb_facing" {
+  default = "internal"
+}
+
+# NLB: idle timeout in seconds, not currently valid for LB type "network"
+variable "nlb_idle_timeout" {
+  default = 60
+}
+
+# NLB: configure cross zone load balancing
+variable "nlb_cross_zone" {
+  default = true
+}
+
+# Label: tags map
+variable "nlb_tags" {
+  type = "map"
+
+  default = {
+    "nlb" = true
+  }
+}
+
+# NLB: EC2 Instance list to add to target groups
+variable "nlb_tg_instances" {
+  type    = "list"
+  default = []
+}
+
+# S3: Access Logs Bucket
+variable "nlb_al_bucket" {
+  default = "__UNSET__"
+}
+
+# S3: A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable.
+variable "force_destroy_log_bucket" {
+  default = false
+}
+
+/*  NLB: listener map
+
+e.g.
+nlb_listener_map = {
+  "0" = {
+    "port"            = "80"
+    "protocol"        = "TCP"
+    "target_group"    = "${aws_lb_target_group.nlb_tg.arn}"
+  }
+}
+*/
+variable "nlb_listener_map" {
+  type = "map"
+}
+
+/*
+  NLB: target group map
+
+e.g.
+nlb_tg_map  = {
+  "listener1" = {
+    "name"          = "listener1-tg-name"
+    "port"          = "80"
+    "protocol"      = "HTTP"
+    "dereg_delay"   = "300"
+    "target_type"   = "instance"
+  }
+}
+*/
+variable "nlb_tg_map" {
+  type = "map"
+}
+
+/* NLB: tg health checks
+e.g.
+nlb_hc_map  = {
+  "listener1" = {
+      protocol            = "TCP"
+      healthy_threshold   = "3"
+      unhealthy_threshold = "3"
+      interval            = "30"
+    }
+  "listener2" = {
+      protocol            = "TCP"
+      healthy_threshold   = "3"
+      unhealthy_threshold = "3"
+      interval            = "30"
+    }
+}
+*/
+variable "nlb_hc_map" {
+  type = "map"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -9,20 +9,18 @@ variable environment {
   default = "noenv"
 }
 
-/*
 # Route53: the zone_id in which to create our CNAME
 variable "route53_zone_id" {
   type    = "string"
   default = "__UNSET__"
 }
-*/
 
 # VPC: list of subnet ids (1 per AZ only) to attach to this NLB
 variable "nlb_subnet_ids" {
   type = "list"
 }
 
-# VPC: explicitly tell terraform how many to expect
+# VPC: explicitly tell terraform how many subnets to expect
 variable "nlb_eni_count" {
   default = "0"
 }


### PR DESCRIPTION
Hi,

This is a functionally complete NLB module based on the work I did for CAP Magento where I originally had the NLB as the bottom part of the Varnish sandwich. I've revised this somewhat to be more suitable for general use than perhaps it was. 

The README provides a basic example, but does not exercise all the options. The `variables.tf` is documented according to the CAP convention and comprehensive explanations an, in some case, examples are provided.

This has been thoroughly tested in my test environment using the following `tfvars`

``` HCL
nlb_name = "alfred"

nlb_eni_count = 0

vpc_id = "vpc-0bed9eb56cbc16b15"

#route53_zone_id = "Z3KMN4RV01W3YQ"

nlb_subnet_ids = ["subnet-0006d25b0a59a3f94", "subnet-01f7ba2a6449cf9fc"]

nlb_listener_map = {
  listener1 = {
    port     = 80
    protocol = "TCP"
  }

  listener2 = {
    port     = 8080
    protocol = "TCP"
  }
}

# if name is not defined, then the map index is used
nlb_tg_map = {
  listener1 = {
    #name       = "listener1-tg-name"
    port        = 80
    protocol    = "TCP"
    dereg_delay = 300
    target_type = "instance"
  }

  listener2 = {
    #name       = "listener2-tg-name"
    port        = 8080
    protocol    = "TCP"
    dereg_delay = 300
    target_type = "instance"
  }
}

nlb_hc_map = {
  listener1 = {
    protocol            = "TCP"
    healthy_threshold   = 3
    unhealthy_threshold = 3
    interval            = 30
  }

  listener2 = {
    protocol            = "TCP"
    healthy_threshold   = 3
    unhealthy_threshold = 3
    interval            = 30
  }
}

```