### PR TITLE
Initial contribution to NLB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,109 @@
 # aws-terraform-nlb
+
+This module provides the functionality to deploy a Network Load Balancer complete with listeners and target groups.
+
+## Usage:
+this and other examples available [here](examples/)
+
+```
+module "nlb" {
+ source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-nlb.git?ref=<git tag, branch, or commit hash here>"
+ environment    = "Test"
+ nlb_name       = "MyNLB"
+
+ vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
+ nlb_subnet_ids = ["subnet-xxxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxxx"]
+
+ # enable alarm actions for TG alarms. vars available for these parameters
+ enable_cloudwatch_alarm_actions = "true"
+
+ nlb_tags      = {
+     "role"    = "load-balancer"
+     "contact" = "someone@somewhere.com"
+ }
+
+ nlb_listener_map = {
+   listener1 = {
+     port = 80
+   }
+
+   listener2 = {
+     port = 8080
+   }
+ }
+
+ # if `name` is not defined, then the map index is used for this value
+ nlb_tg_map = {
+   listener1 = {
+     name       = "listener1-tg-name"
+     port        = 80
+     dereg_delay = 300
+     target_type = "instance"
+   }
+
+   listener2 = {
+     name       = "listener2-tg-name"
+     port        = 8080
+     dereg_delay = 300
+     target_type = "instance"
+   }
+ }
+
+ nlb_hc_map = {
+   listener1 = {
+     protocol            = "TCP"
+     healthy_threshold   = 3
+     unhealthy_threshold = 3
+     interval            = 30
+   }
+
+   listener2 = {
+     protocol            = "HTTP"
+     healthy_threshold   = 3
+     unhealthy_threshold = 3
+     interval            = 30
+     matcher             = "200-399"
+     path                = "/"
+   }
+ }
+}
+```
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| enable_cloudwatch_alarm_actions |  | string | `false` | no |
+| environment | Label: environment name e.g. dev; prod | string | `test` | no |
+| nlb_alarm_topic | CloudWatch: SNS topic for alarm actions | string | `rackspace-support-emergency` | no |
+| nlb_cross_zone | NLB: configure cross zone load balancing | string | `true` | no |
+| nlb_eni_count | VPC: explicitly tell terraform how many subnets to expect | string | `0` | no |
+| nlb_facing | NLB: is this load-balancer "internal" or "external"? | string | `external` | no |
+| nlb_hc_map | /* NLB: tg health checks e.g. nlb_hc_map  = {   "listener1" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     }   "listener2" = {       protocol            = "HTTP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"       matcher             = "200-399"       path                = "/"     } } */ | map | - | yes |
+| nlb_listener_map | /*  NLB: listener map<br><br>e.g. nlb_listener_map = {   "0" = {     "port"            = "80"     "target_group"    = "arn:aws:elasticloadbalancing:xxxxxxx" # optionally specify existing TG ARN   } } */ | map | - | yes |
+| nlb_name | Label: name for this load balancer | string | - | yes |
+| nlb_subnet_ids | VPC: list of subnet ids (1 per AZ only) to attach to this NLB | list | - | yes |
+| nlb_subnet_map | VPC: **not implemented** subnet -> EIP mapping | map | `<map>` | no |
+| nlb_tags | Label: tags map | map | `<map>` | no |
+| nlb_tg_map | /*   NLB: target group map<br><br>e.g. nlb_tg_map  = {   "listener1" = {     "name"          = "listener1-tg-name"     "port"          = "80"     "dereg_delay"   = "300"     "target_type"   = "instance"   } } */ | map | - | yes |
+| nlb_unhealthy_hosts_alarm_evaluation_periods | CloudWatch: alarm sample count threhold | string | `10` | no |
+| nlb_unhealthy_hosts_alarm_period | CloudWatch: alarm sample period in seconds | string | `60` | no |
+| nlb_unhealthy_hosts_alarm_threshold | CloudWatch: number of unhealthy hosts to trigger on | string | `1` | no |
+| route53_zone_id | Route53: the zone_id in which to create our CNAME | string | `__UNSET__` | no |
+| vpc_id | VPC: VPC ID | string | - | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| dns_name | output: the DNS name of the load balancer |
+| load_balancer_arn_suffix | output: The ARN suffix for use with CloudWatch Metrics. |
+| load_balancer_id | output: the ID and ARN of the load balancer |
+| load_balancer_zone_id | output: The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record). |
+| nlb_eni_ips | NLB: the private IPs of this LB for use in EC2 security groups |
+| target_group_arn_suffixes | NLB: ARN suffixes of our target groups - can be used with CloudWatch. |
+| target_group_arns | NLB: ARNs of the target groups. Useful for passing to your Auto Scaling group. |
+| target_group_names | NLB: Name of the target group. Useful for passing to your CodeDeploy Deployment Group |
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ module "nlb" {
 }
 ```
 
+## Limitations
+
+- Current module does not support the use of elastic IPs on the NLB at this time, due to a limitation in generating the SubnetMappings list.  This is expected to be corrected with the release of terraform v0.12.
 
 
 ## Inputs
@@ -77,7 +80,6 @@ module "nlb" {
 |------|-------------|:----:|:-----:|:-----:|
 | enable_cloudwatch_alarm_actions |  | string | `false` | no |
 | environment | Label: environment name e.g. dev; prod | string | `test` | no |
-| nlb_alarm_topic | CloudWatch: SNS topic for alarm actions | string | `rackspace-support-emergency` | no |
 | nlb_cross_zone | NLB: configure cross zone load balancing | string | `true` | no |
 | nlb_eni_count | VPC: explicitly tell terraform how many subnets to expect | string | `0` | no |
 | nlb_facing | NLB: is this load-balancer "internal" or "external"? | string | `external` | no |
@@ -88,9 +90,6 @@ module "nlb" {
 | nlb_subnet_map | VPC: **not implemented** subnet -> EIP mapping | map | `<map>` | no |
 | nlb_tags | Label: tags map | map | `<map>` | no |
 | nlb_tg_map | /*   NLB: target group map<br><br>e.g. nlb_tg_map  = {   "listener1" = {     "name"          = "listener1-tg-name"     "port"          = "80"     "dereg_delay"   = "300"     "target_type"   = "instance"   } } */ | map | - | yes |
-| nlb_unhealthy_hosts_alarm_evaluation_periods | CloudWatch: alarm sample count threhold | string | `10` | no |
-| nlb_unhealthy_hosts_alarm_period | CloudWatch: alarm sample period in seconds | string | `60` | no |
-| nlb_unhealthy_hosts_alarm_threshold | CloudWatch: number of unhealthy hosts to trigger on | string | `1` | no |
 | route53_zone_id | Route53: the zone_id in which to create our CNAME | string | `__UNSET__` | no |
 | vpc_id | VPC: VPC ID | string | - | yes |
 

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,4 @@
-# Determine NLB AWS Account ID for bucket policy: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy 
+# Determine NLB AWS Account ID for bucket policy: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy
 data "aws_elb_service_account" "nlb_svc_acct" {}
 
 data "aws_region" "current" {}
@@ -17,7 +17,7 @@ data "aws_network_interface" "nlb_eni" {
   # this data source does not permit muliple results
 
   # Allow for a static value for nlb_eni_count
-  count = "${var.nlb_eni_count > 0 ? "${var.nlb_eni_count}" : length(var.nlb_subnet_ids)}"
+  count = "${var.nlb_eni_count}"
 
   filter {
     name = "description"

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,61 @@
+# Determine NLB AWS Account ID for bucket policy: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy 
+data "aws_elb_service_account" "nlb_svc_acct" {}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+resource "random_id" "random_string" {
+  byte_length = 8
+
+  keepers {
+    name = "${var.nlb_name}"
+  }
+}
+
+data "aws_network_interface" "nlb_eni" {
+  # this data source does not permit muliple results
+
+  # Allow for a static value for nlb_eni_count
+  count = "${var.nlb_eni_count > 0 ? "${var.nlb_eni_count}" : length(var.nlb_subnet_ids)}"
+
+  filter {
+    name = "description"
+
+    values = [
+      "ELB net/${var.nlb_name}/*",
+    ]
+  }
+
+  filter {
+    name = "subnet-id"
+
+    values = [
+      "${element(var.nlb_subnet_ids,count.index)}",
+    ]
+  }
+
+  # terraform has no way of determining this dependency unaided
+  depends_on = ["aws_lb.nlb"]
+}
+
+/*
+# Error: data.aws_network_interfaces.nlb_enis: Provider doesn't support data source: aws_network_interfaces
+# and yet: https://www.terraform.io/docs/providers/aws/d/network_interfaces.html
+
+data "aws_network_interfaces" "nlb_enis" {
+  filter {
+    name = "description"
+
+    values = [
+      "ELB net/${var.nlb_name}/*",
+    ]
+  }
+  depends_on = ["aws_lb.nlb"]
+}
+*/
+
+data "aws_route53_zone" "provided" {
+  count   = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
+  zone_id = "${var.route53_zone_id}"
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,60 @@
+module "nlb" {
+  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-nlb.git?ref=<git tag, branch, or commit hash here>"
+  environment    = "Test"
+  nlb_name       = "MyNLB"
+  vpc_id         = "vpc-xxxxxxxxxxxxxxxx"
+  nlb_subnet_ids = ["subnet-xxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxx"]
+
+  # enable alarm actions for TG alarms. vars available for these parameters
+  enable_cloudwatch_alarm_actions = "true"
+
+  nlb_tags = {
+    "role"    = "load-balancer"
+    "contact" = "someone@somewhere.com"
+  }
+
+  nlb_listener_map = {
+    listener1 = {
+      port = 80
+    }
+
+    listener2 = {
+      port = 8080
+    }
+  }
+
+  # if `name` is not defined, then the map index is used for this value
+  nlb_tg_map = {
+    listener1 = {
+      name        = "listener1-tg-name"
+      port        = 80
+      dereg_delay = 300
+      target_type = "instance"
+    }
+
+    listener2 = {
+      name        = "listener2-tg-name"
+      port        = 8080
+      dereg_delay = 300
+      target_type = "instance"
+    }
+  }
+
+  nlb_hc_map = {
+    listener1 = {
+      protocol            = "TCP"
+      healthy_threshold   = 3
+      unhealthy_threshold = 3
+      interval            = 30
+    }
+
+    listener2 = {
+      protocol            = "HTTP"
+      healthy_threshold   = 3
+      unhealthy_threshold = 3
+      interval            = 30
+      matcher             = "200-399"
+      path                = "/"
+    }
+  }
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  default_tg_params = {
+    dereg_delay = 300
+    target_type = "instance"
+  }
+
+  default_health_check = {
+    protocol            = "TCP"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    interval            = 30
+  }
+
+  tg_keys = "${keys(var.nlb_tg_map)}"
+  lm_keys = "${keys(var.nlb_listener_map)}"
+  hc_keys = "${keys(var.nlb_hc_map)}"
+
+  tags = "${merge(var.nlb_tags, map("Environment", "${var.environment}", "ServiceProvider", "Rackspace"))}"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,164 @@
+/**
+* # aws-terraform-nlb
+*
+* This module provides the functionality to deploy a Network Load Balancer complete with listeners and target groups.
+*
+* ## Usage: 
+*this and other examples available [here](examples/)
+*
+*```
+*module "nlb" {
+*  source         = "git@github.com:rackspace-infrastructure-automation/aws-terraform-nlb.git?ref=<git tag, branch, or commit hash here>"
+*  environment    = "Test"
+*  nlb_name       = "MyNLB"
+*
+*  vpc_id = "vpc-xxxxxxxxxxxxxxxxx"
+*  nlb_subnet_ids = ["subnet-xxxxxxxxxxxxxxxxx", "subnet-xxxxxxxxxxxxxxxxx"]
+*
+*  # enable alarm actions for TG alarms. vars available for these parameters
+*  enable_cloudwatch_alarm_actions = "true"
+*
+*  nlb_tags      = {
+*      "role"    = "load-balancer"
+*      "contact" = "someone@somewhere.com"
+*  }
+*
+*  nlb_listener_map = {
+*    listener1 = {
+*      port = 80
+*    }
+*
+*    listener2 = {
+*      port = 8080
+*    }
+*  }
+*
+*  # if `name` is not defined, then the map index is used for this value
+*  nlb_tg_map = {
+*    listener1 = {
+*      name       = "listener1-tg-name"
+*      port        = 80
+*      dereg_delay = 300
+*      target_type = "instance"
+*    }
+*
+*    listener2 = {
+*      name       = "listener2-tg-name"
+*      port        = 8080
+*      dereg_delay = 300
+*      target_type = "instance"
+*    }
+*  }
+*
+*  nlb_hc_map = {
+*    listener1 = {
+*      protocol            = "TCP"
+*      healthy_threshold   = 3
+*      unhealthy_threshold = 3
+*      interval            = 30
+*    }
+*
+*    listener2 = {
+*      protocol            = "HTTP"
+*      healthy_threshold   = 3
+*      unhealthy_threshold = 3
+*      interval            = 30
+*      matcher             = "200-399"
+*      path                = "/"
+*    }
+*  }
+*}
+*```
+*
+**/
+
+resource "aws_lb" "nlb" {
+  name               = "${var.nlb_name}"
+  internal           = "${var.nlb_facing == "internal" ? true : false}"
+  load_balancer_type = "network"
+
+  enable_cross_zone_load_balancing = "${var.nlb_cross_zone}"
+
+  subnets = ["${var.nlb_subnet_ids}"]
+  tags    = "${local.tags}"
+}
+
+resource "aws_lb_target_group" "nlb_tg" {
+  count = "${length(local.tg_keys)}"
+
+  vpc_id = "${var.vpc_id}"
+
+  name = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"name", "__UNSET__") == "__UNSET__"
+       ? "${var.nlb_name}-${element(local.tg_keys,count.index)}-tg"
+       : lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"name", "__UNSET__")}"
+
+  port                 = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"port")}"
+  protocol             = "TCP"
+  deregistration_delay = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"dereg_delay","300")}"
+  target_type          = "${lookup(var.nlb_tg_map[element(local.tg_keys,count.index)],"target_type","instance")}"
+
+  tags = "${local.tags}"
+
+  health_check {
+    protocol            = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"protocol")}"
+    healthy_threshold   = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"healthy_threshold","3")}"
+    unhealthy_threshold = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"unhealthy_threshold","3")}"
+    interval            = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"interval","30")}"
+    matcher             = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"matcher","")}"
+    path                = "${lookup(var.nlb_hc_map[element(local.hc_keys,count.index)],"path","")}"
+  }
+}
+
+resource "aws_lb_listener" "nlb_listener" {
+  count = "${length(local.lm_keys)}"
+
+  load_balancer_arn = "${aws_lb.nlb.arn}"
+  port              = "${lookup(var.nlb_listener_map[element(local.lm_keys,count.index)],"port")}"
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.nlb_tg.*.arn[count.index]}"
+    type             = "forward"
+  }
+}
+
+resource "aws_route53_record" "route53_nlb_cname" {
+  count = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
+
+  zone_id = "${var.route53_zone_id}"
+  name    = "${var.nlb_name}-${var.environment}-nlb"
+  records = ["${aws_lb.nlb.dns_name}"]
+  type    = "CNAME"
+  ttl     = "5"
+}
+
+resource "aws_cloudwatch_metric_alarm" "nlb_unhealthy_hosts" {
+  count           = "${length(local.tg_keys)}"
+  actions_enabled = "${var.enable_cloudwatch_alarm_actions}"
+
+  alarm_actions = [
+    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
+  ]
+
+  alarm_description   = "Unhealthy Host count is above threshold, creating ticket."
+  alarm_name          = "NLB Unhealthy Host Count - ${aws_lb.nlb.name}-${aws_lb_target_group.nlb_tg.*.name[count.index]}"
+  comparison_operator = "GreaterThanThreshold"
+
+  dimensions = {
+    LoadBalancer = "${aws_lb.nlb.arn_suffix}"
+    TargetGroup  = "${aws_lb_target_group.nlb_tg.*.arn_suffix[count.index]}"
+  }
+
+  evaluation_periods = "10"
+  metric_name        = "UnHealthyHostCount"
+  namespace          = "AWS/NetworkELB"
+
+  ok_actions = [
+    "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency",
+  ]
+
+  period    = "60"
+  statistic = "Maximum"
+  threshold = "1"
+  unit      = "Count"
+}

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 *
 * This module provides the functionality to deploy a Network Load Balancer complete with listeners and target groups.
 *
-* ## Usage: 
+* ## Usage:
 *this and other examples available [here](examples/)
 *
 *```
@@ -70,6 +70,9 @@
 *}
 *```
 *
+ * ## Limitations
+ *
+ * - Current module does not support the use of elastic IPs on the NLB at this time, due to a limitation in generating the SubnetMappings list.  This is expected to be corrected with the release of terraform v0.12.
 **/
 
 resource "aws_lb" "nlb" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,47 @@
+/*
+### Outputs section for the NLB module
+
+For consistency, it is intended to mimic as far as applicable the [community ALB module](https://github.com/terraform-aws-modules/terraform-aws-alb/blob/master/outputs.tf)
+[Parent module](https://github.com/terraform-aws-modules/terraform-aws-alb)
+
+*/
+
+# output: the DNS name of the load balancer
+output "dns_name" {
+  value = "${aws_lb.nlb.dns_name}"
+}
+
+# output: the ID and ARN of the load balancer
+output "load_balancer_id" {
+  value = "${aws_lb.nlb.id}"
+}
+
+# output: The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record).
+output "load_balancer_zone_id" {
+  value = "${aws_lb.nlb.zone_id}"
+}
+
+# output: The ARN suffix for use with CloudWatch Metrics.
+output "load_balancer_arn_suffix" {
+  value = "${aws_lb.nlb.arn_suffix}"
+}
+
+# NLB: ARNs of the target groups. Useful for passing to your Auto Scaling group.
+output "target_group_arns" {
+  value = "${flatten(aws_lb_target_group.nlb_tg.*.arn)}"
+}
+
+# NLB: ARN suffixes of our target groups - can be used with CloudWatch.
+output "target_group_arn_suffixes" {
+  value = "${flatten(aws_lb_target_group.nlb_tg.*.arn_suffix)}"
+}
+
+# NLB: Name of the target group. Useful for passing to your CodeDeploy Deployment Group
+output "target_group_names" {
+  value = "${flatten(aws_lb_target_group.nlb_tg.*.name)}"
+}
+
+# NLB: the private IPs of this LB for use in EC2 security groups
+output "nlb_eni_ips" {
+  value = "${flatten(data.aws_network_interface.nlb_eni.*.private_ips)}"
+}

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -41,7 +41,7 @@ module "vpc" {
 module "nlb_external" {
   source = "../../module"
 
-  nlb_name       = "${random_string.rstring.result}-test-nlb"
+  nlb_name       = "${random_string.rstring.result}-nlb-ext"
   vpc_id         = "${module.vpc.vpc_id}"
   nlb_subnet_ids = "${module.vpc.public_subnets}"
   nlb_eni_count  = 2
@@ -73,7 +73,7 @@ module "nlb_external" {
 module "nlb_internal" {
   source = "../../module"
 
-  nlb_name       = "${random_string.rstring.result}-test-nlb"
+  nlb_name       = "${random_string.rstring.result}-nlb-int"
   vpc_id         = "${module.vpc.vpc_id}"
   nlb_subnet_ids = "${module.vpc.private_subnets}"
   nlb_eni_count  = 2

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -1,12 +1,126 @@
 provider "aws" {
-  version = "~> 1.2, < 1.41.0"
-  region  = "us-east-1"
+  version = "~> 1.2"
+  region  = "us-west-2"
 }
 
-resource "random_string" "r_string" {
-  length  = 6
-  lower   = true
+data "aws_ami" "amz_linux_2" {
+  most_recent = true
+  owners      = ["137112412989"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-2.0.*-ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+resource "random_string" "rstring" {
+  length  = 8
   upper   = false
-  number  = false
   special = false
+}
+
+module "vpc" {
+  source              = "git@github.com:rackspace-infrastructure-automation/aws-terraform-vpc_basenetwork//?ref=master"
+  az_count            = 2
+  cidr_range          = "10.0.0.0/16"
+  public_cidr_ranges  = ["10.0.1.0/24", "10.0.3.0/24"]
+  private_cidr_ranges = ["10.0.2.0/24", "10.0.4.0/24"]
+  vpc_name            = "${random_string.rstring.result}-test"
+}
+
+module "nlb_external" {
+  source = "../../module"
+
+  nlb_name       = "${random_string.rstring.result}-test-nlb"
+  vpc_id         = "${module.vpc.vpc_id}"
+  nlb_subnet_ids = "${module.vpc.public_subnets}"
+  nlb_eni_count  = 2
+
+  nlb_listener_map = {
+    listener1 = {
+      port = 80
+    }
+  }
+
+  nlb_tg_map = {
+    listener1 = {
+      port        = 80
+      dereg_delay = 300
+      target_type = "instance"
+    }
+  }
+
+  nlb_hc_map = {
+    listener1 = {
+      protocol            = "TCP"
+      healthy_threshold   = 3
+      unhealthy_threshold = 3
+      interval            = 30
+    }
+  }
+}
+
+module "nlb_internal" {
+  source = "../../module"
+
+  nlb_name       = "${random_string.rstring.result}-test-nlb"
+  vpc_id         = "${module.vpc.vpc_id}"
+  nlb_subnet_ids = "${module.vpc.private_subnets}"
+  nlb_eni_count  = 2
+  nlb_facing     = "internal"
+
+  nlb_listener_map = {
+    listener1 = {
+      port = 80
+    }
+  }
+
+  nlb_tg_map = {
+    listener1 = {
+      port        = 80
+      dereg_delay = 300
+      target_type = "instance"
+    }
+  }
+
+  nlb_hc_map = {
+    listener1 = {
+      protocol            = "HTTP"
+      healthy_threshold   = 3
+      unhealthy_threshold = 3
+      interval            = 30
+      matcher             = "200-399"
+      path                = "/"
+    }
+  }
+}
+
+module "security_groups" {
+  source        = "git@github.com:rackspace-infrastructure-automation/aws-terraform-security_group//?ref=master"
+  resource_name = "ASGIR-${random_string.rstring.result}"
+  vpc_id        = "${module.vpc.vpc_id}"
+}
+
+module "asg" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-ec2_asg//?ref=master"
+
+  ec2_os              = "amazon"
+  image_id            = "${data.aws_ami.amz_linux_2.image_id}"
+  instance_type       = "t2.micro"
+  resource_name       = "${random_string.rstring.result}-test-asg"
+  security_group_list = ["${module.security_groups.public_web_security_group_id}"]
+  scaling_max         = "2"
+  scaling_min         = "1"
+  subnets             = ["${element(module.vpc.public_subnets, 0)}", "${element(module.vpc.public_subnets, 1)}"]
+  target_group_arns   = ["${concat(module.nlb_external.target_group_arns, module.nlb_internal.target_group_arns)}"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,116 @@
+# Label: name for this load balancer
+variable "nlb_name" {
+  type = "string"
+}
+
+# Label: environment name e.g. dev; prod
+variable environment {
+  type    = "string"
+  default = "test"
+}
+
+# Route53: the zone_id in which to create our CNAME
+variable "route53_zone_id" {
+  type    = "string"
+  default = "__UNSET__"
+}
+
+# VPC: list of subnet ids (1 per AZ only) to attach to this NLB
+variable "nlb_subnet_ids" {
+  type = "list"
+}
+
+# VPC: explicitly tell terraform how many subnets to expect
+variable "nlb_eni_count" {
+  default = "0"
+}
+
+# VPC: VPC ID
+variable "vpc_id" {
+  type = "string"
+}
+
+# VPC: **not implemented** subnet -> EIP mapping
+variable "nlb_subnet_map" {
+  type = "map"
+
+  default = {
+    "0" = ["eip-1", "subnet-1"]
+  }
+}
+
+# NLB: is this load-balancer "internal" or "external"? 
+variable "nlb_facing" {
+  default = "external"
+}
+
+# NLB: configure cross zone load balancing
+variable "nlb_cross_zone" {
+  default = true
+}
+
+# Label: tags map
+variable "nlb_tags" {
+  type = "map"
+
+  default = {}
+}
+
+/*  NLB: listener map
+
+e.g.
+nlb_listener_map = {
+  "0" = {
+    "port"            = "80"
+    "target_group"    = "arn:aws:elasticloadbalancing:xxxxxxx" # optionally specify existing TG ARN
+  }
+}
+*/
+variable "nlb_listener_map" {
+  type = "map"
+}
+
+/*
+  NLB: target group map
+
+e.g.
+nlb_tg_map  = {
+  "listener1" = {
+    "name"          = "listener1-tg-name"
+    "port"          = "80"
+    "dereg_delay"   = "300"
+    "target_type"   = "instance"
+  }
+}
+*/
+variable "nlb_tg_map" {
+  type = "map"
+}
+
+/* NLB: tg health checks
+e.g.
+nlb_hc_map  = {
+  "listener1" = {
+      protocol            = "TCP"
+      healthy_threshold   = "3"
+      unhealthy_threshold = "3"
+      interval            = "30"
+    }
+  "listener2" = {
+      protocol            = "HTTP"
+      healthy_threshold   = "3"
+      unhealthy_threshold = "3"
+      interval            = "30"
+      matcher             = "200-399"
+      path                = "/"
+    }
+}
+*/
+variable "nlb_hc_map" {
+  type = "map"
+}
+
+variable "enable_cloudwatch_alarm_actions" {
+  type    = "string"
+  default = "false"
+}


### PR DESCRIPTION
Relocating #1 originally submitted by @njgarratt to allow for CI execution.  Original submission below:

>Hi,
>
>This is a functionally complete NLB module based on the work I did for CAP Magento where I originally had the NLB as the bottom part of the Varnish sandwich. I've revised this somewhat to be more suitable for general use than perhaps it was. 
>
>The README provides a basic example, but does not exercise all the options. The `variables.tf` is documented according to the CAP convention and comprehensive explanations an, in some case, examples are provided.
>
>This has been thoroughly tested in my test environment using the following `tfvars`
>
>``` HCL
>nlb_name = "alfred"
>
>nlb_eni_count = 0
>
>vpc_id = "vpc-0bed9eb56cbc16b15"
>
>#route53_zone_id = "Z3KMN4RV01W3YQ"
>
>nlb_subnet_ids = ["subnet-0006d25b0a59a3f94", "subnet-01f7ba2a6449cf9fc"]
>
>nlb_listener_map = {
>  listener1 = {
>    port     = 80
>    protocol = "TCP"
>  }
>
>  listener2 = {
>    port     = 8080
>    protocol = "TCP"
>  }
>}
>
> # if name is not defined, then the map index is used
> nlb_tg_map = {
>   listener1 = {
>     #name       = "listener1-tg-name"
>     port        = 80
>     protocol    = "TCP"
>     dereg_delay = 300
>     target_type = "instance"
>   }
> 
>   listener2 = {
>     #name       = "listener2-tg-name"
>     port        = 8080
>     protocol    = "TCP"
>     dereg_delay = 300
>     target_type = "instance"
>   }
> }
> 
> nlb_hc_map = {
>   listener1 = {
>     protocol            = "TCP"
>     healthy_threshold   = 3
>     unhealthy_threshold = 3
>     interval            = 30
>   }
> 
>   listener2 = {
>     protocol            = "TCP"
>     healthy_threshold   = 3
>     unhealthy_threshold = 3
>     interval            = 30
>   }
> }
> 
> ```

The following changes are also included in this PR

- CI test updated to create an external and internal NLB, and associate the target groups from each with an ALB.
- Blurb added to module readme regarding lack of support for SubnetMappings\EIP assignment.
- When provided subnets directly from the VPC module output, the count for `aws_network_interface.nlb_eni` was reported as calculated, even if the `nlb_eni_count` variable was defined.  That portion of that count looking up the length of the `nlb_subnet_ids` variable has been removed.