### PR TITLE
Modify route53 record creation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,19 +78,21 @@ module "nlb" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| enable_cloudwatch_alarm_actions |  | string | `false` | no |
-| environment | Label: environment name e.g. dev; prod | string | `test` | no |
+| create_internal_zone_record | Create Route 53 internal zone record for the NLB. i.e true | false | string | `false` | no |
 | cross_zone | NLB: configure cross zone load balancing | string | `true` | no |
+| enable_cloudwatch_alarm_actions |  | string | `false` | no |
 | eni_count | VPC: explicitly tell terraform how many subnets to expect | string | `0` | no |
+| environment | Label: environment name e.g. dev; prod | string | `test` | no |
 | facing | NLB: is this load-balancer "internal" or "external"? | string | `external` | no |
 | hc_map | /* NLB: tg health checks e.g. hc_map  = {   "listener1" = {       protocol            = "TCP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"     }   "listener2" = {       protocol            = "HTTP"       healthy_threshold   = "3"       unhealthy_threshold = "3"       interval            = "30"       matcher             = "200-399"       path                = "/"     } } */ | map | - | yes |
 | listener_map | /*  NLB: listener map<br><br>e.g. listener_map = {   "0" = {     "port"            = "80"     "target_group"    = "arn:aws:elasticloadbalancing:xxxxxxx" # optionally specify existing TG ARN   } } */ | map | - | yes |
 | name | Label: name for this load balancer | string | - | yes |
+| route53_internal_record_name | Record Name for the new Resource Record in the Internal Hosted Zone. i.e. nlb.example.com | string | `` | no |
+| route53_zone_id | Route53: the zone_id in which to create our CNAME | string | `` | no |
 | subnet_ids | VPC: list of subnet ids (1 per AZ only) to attach to this NLB | list | - | yes |
 | subnet_map | VPC: **not implemented** subnet -> EIP mapping | map | `<map>` | no |
 | tags | Label: tags map | map | `<map>` | no |
 | tg_map | /*   NLB: target group map<br><br>e.g. tg_map  = {   "listener1" = {     "name"          = "listener1-tg-name"     "port"          = "80"     "dereg_delay"   = "300"     "target_type"   = "instance"   } } */ | map | - | yes |
-| route53_zone_id | Route53: the zone_id in which to create our CNAME | string | `__UNSET__` | no |
 | vpc_id | VPC: VPC ID | string | - | yes |
 
 ## Outputs
@@ -98,10 +100,10 @@ module "nlb" {
 | Name | Description |
 |------|-------------|
 | dns_name | output: the DNS name of the load balancer |
+| eni_ips | NLB: the private IPs of this LB for use in EC2 security groups |
 | load_balancer_arn_suffix | output: The ARN suffix for use with CloudWatch Metrics. |
 | load_balancer_id | output: the ID and ARN of the load balancer |
 | load_balancer_zone_id | output: The canonical hosted zone ID of the load balancer (to be used in a Route 53 Alias record). |
-| eni_ips | NLB: the private IPs of this LB for use in EC2 security groups |
 | target_group_arn_suffixes | NLB: ARN suffixes of our target groups - can be used with CloudWatch. |
 | target_group_arns | NLB: ARNs of the target groups. Useful for passing to your Auto Scaling group. |
 | target_group_names | NLB: Name of the target group. Useful for passing to your CodeDeploy Deployment Group |

--- a/data.tf
+++ b/data.tf
@@ -55,7 +55,3 @@ data "aws_network_interfaces" "enis" {
 }
 */
 
-data "aws_route53_zone" "provided" {
-  count   = "${var.route53_zone_id == "__UNSET__" ? 0:1}"
-  zone_id = "${var.route53_zone_id}"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -9,10 +9,22 @@ variable environment {
   default = "test"
 }
 
-# Route53: the zone_id in which to create our CNAME
-variable "route53_zone_id" {
+variable "create_internal_zone_record" {
+  description = "Create Route 53 internal zone record for the NLB. i.e true | false"
+  type        = "string"
+  default     = false
+}
+
+variable "internal_record_name" {
+  description = "Record Name for the new Resource Record in the Internal Hosted Zone. i.e. nlb.example.com"
+  type        = "string"
+  default     = ""
+}
+
+# Route53: the zone_id in which to create our ALIAS
+variable "route_53_hosted_zone_id" {
   type    = "string"
-  default = "__UNSET__"
+  default = ""
 }
 
 # VPC: list of subnet ids (1 per AZ only) to attach to this NLB


### PR DESCRIPTION
Resolves issue: https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/178

- Modify route 53 record provisioning to create ALIAS record instead of CNAME to match alb.
- Add route53 record provisioning to test
- Add route53 record provisioning variable "switch"
- Remove unneeded data query
- Rename route53-related variable(s) to match alb.
- Update README