### PR TITLE
Add support for TLS Termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ module "nlb" {
    }
 
    listener2 = {
-     port = 8080
+     certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+     port     = 443
+     protocol = "TLS"
    }
  }
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -19,7 +19,9 @@ module "nlb" {
     }
 
     listener2 = {
-      port = 8080
+      certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      port            = 443
+      protocol        = "TLS"
     }
   }
 

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -23,6 +23,12 @@ data "aws_ami" "amz_linux_2" {
   }
 }
 
+data "aws_acm_certificate" "cert" {
+  domain      = "www.mupo181ve1jco37.net"
+  statuses    = ["ISSUED"]
+  most_recent = true
+}
+
 resource "random_string" "rstring" {
   length  = 8
   upper   = false
@@ -49,6 +55,12 @@ module "external" {
   listener_map = {
     listener1 = {
       port = 80
+    }
+
+    listener2 = {
+      certificate_arn = "${data.aws_acm_certificate.cert.arn}"
+      port            = 443
+      protocol        = "TLS"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,10 @@ variable "tags" {
 e.g.
 listener_map = {
   "0" = {
+    "certificate_arn" = "arn:aws:acm:us-east-1:123456789012:certificate/12345678-90ab-cdef-1234-567890abcdef>" # Required for the TLS protocol
     "port"            = "80"
+    "protocol"        = "TCP" # Defaults to TCP.  Allowed values: TCP, TLS
+    "ssl_protocol"    = "ELBSecurityPolicy-TLS-1-2-2017-02" # Optional, to set a specific SSL Policy.
     "target_group"    = "arn:aws:elasticloadbalancing:xxxxxxx" # optionally specify existing TG ARN
   }
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
rackspace-infrastructure-automation/aws-terraform-internal#221
##### Summary of change(s):
Add support for TLS protocol option for NLB listeners. 
Updates tests to utilize TLS for one listener.
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
Yes, readme has been updated
##### Do examples need to be updated based on changes?
Yes, examples have been updated

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.