### PR TITLE
Fix data source for aws_network_interface

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -32,3 +32,17 @@ data "aws_network_interface" "eni" {
     ]
   }
 }
+
+/*
+# Error: data.aws_network_interfaces.enis: Provider doesn't support data source: aws_network_interfaces
+# and yet: https://www.terraform.io/docs/providers/aws/d/network_interfaces.html
+data "aws_network_interfaces" "enis" {
+  filter {
+    name = "description"
+    values = [
+      "ELB net/${var.name}/*",
+    ]
+  }
+  depends_on = ["aws_lb.nlb"]
+}
+*/

--- a/data.tf
+++ b/data.tf
@@ -46,3 +46,4 @@ data "aws_network_interfaces" "enis" {
   depends_on = ["aws_lb.nlb"]
 }
 */
+

--- a/data.tf
+++ b/data.tf
@@ -14,16 +14,13 @@ resource "random_id" "random_string" {
 }
 
 data "aws_network_interface" "eni" {
-  # this data source does not permit muliple results
-
-  # Allow for a static value for eni_count
-  count = "${var.eni_count}"
+  count = "${length(var.subnet_ids)}"
 
   filter {
     name = "description"
 
     values = [
-      "ELB net/${var.name}/*",
+      "ELB ${aws_lb.nlb.arn_suffix}",
     ]
   }
 
@@ -34,24 +31,4 @@ data "aws_network_interface" "eni" {
       "${element(var.subnet_ids,count.index)}",
     ]
   }
-
-  # terraform has no way of determining this dependency unaided
-  depends_on = ["aws_lb.nlb"]
 }
-
-/*
-# Error: data.aws_network_interfaces.enis: Provider doesn't support data source: aws_network_interfaces
-# and yet: https://www.terraform.io/docs/providers/aws/d/network_interfaces.html
-
-data "aws_network_interfaces" "enis" {
-  filter {
-    name = "description"
-
-    values = [
-      "ELB net/${var.name}/*",
-    ]
-  }
-  depends_on = ["aws_lb.nlb"]
-}
-*/
-


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):

##### Summary of change(s):
Hello,

This PR is to fix the data source for `aws_network_interface.eni`, and by extension, the output for `eni_ips`

The proposed change uses the length of variable `subnet_ids` for the count, and a slight change to the description filter to use the value of `aws_lb.nlb.arn_suffix`.

I have tested this change to the best of my abilities and am seeing outputs for `eni_ips`, here is a snippet:
```
eni_ips = [
    10.100.6.80,
    10.100.7.24
]
```

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No, this only affects a data source that previously returned an empty output.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
This does not alter input our output variables, only the data source that the output `eni_ips` uses

##### Do examples need to be updated based on changes?
No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.