### PR TITLE
Address dynamic count issue when listener map has a cert arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ module "nlb" {
 | hc\_map | health check map | map | n/a | yes |
 | internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone. i.e. nlb.example.com | string | `""` | no |
 | listener\_map | listener map | map | n/a | yes |
+| listener\_map\_count | The number of listener maps to utilize | string | `"1"` | no |
 | name | name for this load balancer | string | n/a | yes |
 | notification\_topic | List of SNS Topic ARNs to use for customer notifications. | list | `<list>` | no |
 | rackspace\_alarms\_enabled | Specifies whether alarms will create a Rackspace ticket.  Ignored if rackspace_managed is set to false. | string | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -114,7 +114,7 @@ resource "aws_lb_target_group" "tg" {
 }
 
 resource "aws_lb_listener" "listener" {
-  count = "${length(local.lm_keys)}"
+  count = "${var.listener_map_count}"
 
   certificate_arn   = "${lookup(var.listener_map[element(local.lm_keys, count.index)], "certificate_arn", "")}"
   load_balancer_arn = "${aws_lb.nlb.arn}"

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -47,10 +47,11 @@ module "vpc" {
 module "external" {
   source = "../../module"
 
-  name       = "${random_string.rstring.result}-nlb-ext"
-  vpc_id     = "${module.vpc.vpc_id}"
-  subnet_ids = "${module.vpc.public_subnets}"
-  eni_count  = 2
+  name               = "${random_string.rstring.result}-nlb-ext"
+  vpc_id             = "${module.vpc.vpc_id}"
+  subnet_ids         = "${module.vpc.public_subnets}"
+  listener_map_count = 2
+  eni_count          = 2
 
   listener_map = {
     listener1 = {

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "internal_record_name" {
   default     = ""
 }
 
+variable "listener_map_count" {
+  description = "The number of listener maps to utilize"
+  type        = "string"
+  default     = "1"
+}
+
 variable "route_53_hosted_zone_id" {
   type        = "string"
   default     = ""


### PR DESCRIPTION
* Previously counts for listener would not work if one of the entries had a dynamic value such as a certificate arn
* To compensate for this modules will now require a static count defined instead (default 1)

##### Corresponding Issue(s):
 - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section

##### Summary of change(s):

##### Reason for Change(s):

- If a bug, describe error scenario, including expected behavior and actual behavior.

- If an enhancement, describe the use case and the perceived benefit(s).

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

##### If input variables or output variables have changed or has been added, have you updated the README?

##### Do examples need to be updated based on changes?

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
