### PR TITLE
Add toggle to stickiness due to TF/AWS API issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ module "nlb" {
 Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
   - unhealthy\_host\_count\_alarm
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.20 |
+
 ## Providers
 
 | Name | Version |
@@ -93,7 +100,7 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | create\_internal\_zone\_record | Create Route 53 internal zone record for the NLB. i.e true \| false | `bool` | `false` | no |
 | cross\_zone | configure cross zone load balancing | `bool` | `true` | no |
 | eni\_count | explicitly tell terraform how many subnets to expect | `number` | `0` | no |
@@ -109,7 +116,7 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | `bool` | `true` | no |
 | route\_53\_hosted\_zone\_id | the zone\_id in which to create our ALIAS | `string` | `""` | no |
 | subnet\_ids | list of subnet ids (1 per AZ only) to attach to this NLB | `list(string)` | n/a | yes |
-| subnet\_map | **not implemented** subnet -> EIP mapping | `map(list(string))` | <pre>{<br>  "0": [<br>    "eip-1",<br>    "subnet-1"<br>  ]<br>}</pre> | no |
+| subnet\_map | \*\*not implemented\*\* subnet -> EIP mapping | `map(list(string))` | <pre>{<br>  "0": [<br>    "eip-1",<br>    "subnet-1"<br>  ]<br>}</pre> | no |
 | tags | tags map | `map(string)` | `{}` | no |
 | tg\_map | target group map | `map(map(string))` | n/a | yes |
 | vpc\_id | VPC ID | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -83,13 +83,6 @@ module "nlb" {
 Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm) to create the following CloudWatch Alarms:
   - unhealthy\_host\_count\_alarm
 
-## Requirements
-
-| Name | Version |
-|------|---------|
-| terraform | >= 0.12 |
-| aws | >= 2.20 |
-
 ## Providers
 
 | Name | Version |
@@ -100,7 +93,7 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+|------|-------------|------|---------|:-----:|
 | create\_internal\_zone\_record | Create Route 53 internal zone record for the NLB. i.e true \| false | `bool` | `false` | no |
 | cross\_zone | configure cross zone load balancing | `bool` | `true` | no |
 | eni\_count | explicitly tell terraform how many subnets to expect | `number` | `0` | no |
@@ -116,7 +109,7 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | rackspace\_managed | Boolean parameter controlling if instance will be fully managed by Rackspace support teams, created CloudWatch alarms that generate tickets, and utilize Rackspace managed SSM documents. | `bool` | `true` | no |
 | route\_53\_hosted\_zone\_id | the zone\_id in which to create our ALIAS | `string` | `""` | no |
 | subnet\_ids | list of subnet ids (1 per AZ only) to attach to this NLB | `list(string)` | n/a | yes |
-| subnet\_map | \*\*not implemented\*\* subnet -> EIP mapping | `map(list(string))` | <pre>{<br>  "0": [<br>    "eip-1",<br>    "subnet-1"<br>  ]<br>}</pre> | no |
+| subnet\_map | **not implemented** subnet -> EIP mapping | `map(list(string))` | <pre>{<br>  "0": [<br>    "eip-1",<br>    "subnet-1"<br>  ]<br>}</pre> | no |
 | tags | tags map | `map(string)` | `{}` | no |
 | tg\_map | target group map | `map(map(string))` | n/a | yes |
 | vpc\_id | VPC ID | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -162,9 +162,17 @@ resource "aws_lb_target_group" "tg" {
     "instance",
   )
 
-  stickiness {
-    type    = "lb_cookie"
-    enabled = false
+  dynamic "stickiness" {
+    for_each = lookup(
+      var.tg_map[element(local.tg_keys, count.index)],
+      "stickiness_placeholder",
+      false,
+    ) ? toset(["build"]) : toset([])
+
+    content {
+      enabled = false
+      type    = "lb_cookie"
+    }
   }
 
   health_check {

--- a/tests/test1/main.tf
+++ b/tests/test1/main.tf
@@ -139,9 +139,10 @@ module "external" {
 
   tg_map = {
     listener1 = {
-      dereg_delay = 300
-      port        = 80
-      target_type = "instance"
+      dereg_delay            = 300
+      port                   = 80
+      target_type            = "instance"
+      stickiness_placeholder = true
     }
   }
 
@@ -200,9 +201,10 @@ module "internal" {
 
   tg_map = {
     listener1 = {
-      dereg_delay = 300
-      port        = 80
-      target_type = "instance"
+      dereg_delay            = 300
+      port                   = 80
+      target_type            = "instance"
+      stickiness_placeholder = true
     }
   }
 
@@ -233,4 +235,3 @@ module "asg" {
     module.internal.target_group_arns,
   )
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -145,6 +145,8 @@ tg_map  = {
     "target_type"   = "instance"
   }
 }
+
+N.B. if you receive an error `Network Load Balancers do not support Stickiness` then try adding a key to your problem target groups of `stickiness_placeholder = true`
 */
 variable "tg_map" {
   description = "target group map"


### PR DESCRIPTION
##### Corresponding Issue(s):
<!-- - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section -->

N/A

##### Summary of change(s):

- make new v0.12.1 `stickiness` block a toggled option, missing by default, to allow for current AWS/TF issues

##### Reason for Change(s):

<!-- - If a bug, describe error scenario, including expected behavior and actual behavior. -->

<!-- - If an enhancement, describe the use case and the perceived benefit(s). -->

BUG: due to some issues between Terraform and the AWS API there are mixed results when creating a TCP or UDP TG that sometimes requires `stickiness` to be set in a specific way or not at all.

References:

https://github.com/terraform-providers/terraform-provider-aws/issues/9093#issuecomment-696830753
https://github.com/terraform-providers/terraform-provider-aws/pull/15295

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

Believe not

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

Yes

##### Do examples need to be updated based on changes?

No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
