### PR TITLE
Update CloudWatch Alarm module pinning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -268,7 +268,7 @@ data "null_data_source" "alarm_dimensions" {
 }
 
 module "unhealthy_host_count_alarm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-cloudwatch_alarm//?ref=v0.12.4"
 
   alarm_count              = length(local.tg_keys)
   alarm_description        = "Unhealthy Host count is above threshold, creating ticket."


### PR DESCRIPTION
##### Corresponding Issue(s):
 - [MPCSUPENG-1622](https://jira.rax.io/browse/MPCSUPENG-1622)

##### Summary of change(s):
- Update pinning of CloudWatch Alarm module to 0.12.4

##### Reason for Change(s):

- Keep module references current

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

Yes, CloudWatch Alarm module updated.

##### If input variables or output variables have changed or has been added, have you updated the README?

No

##### Do examples need to be updated based on changes?

No

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
